### PR TITLE
Support .hda extension used with RaSCSI or BlueSCSI.

### DIFF
--- a/src/basilisk/BasiliskII-worker-boot.js
+++ b/src/basilisk/BasiliskII-worker-boot.js
@@ -27,7 +27,7 @@ function isCDImage(filename = '') {
 }
 
 function isDiskImage(filename = '') {
-  return filename.endsWith('.img') || filename.endsWith('.dsk');
+  return filename.endsWith('.img') || filename.endsWith('.dsk') || filename.endsWith('.hda');
 }
 
 function cleanupCopyPath() {


### PR DESCRIPTION
Macintosh.js is great for beginners - this patch allows users to just drop a RaSCSI or BlueSCSI image in the shared folder and mount it to transfer files in and out. Useful when moving between modern/vintage computers.